### PR TITLE
ユーザが部屋を作れる その2

### DIFF
--- a/wordwolf-backend/src/rooms/controller/rooms.controller.ts
+++ b/wordwolf-backend/src/rooms/controller/rooms.controller.ts
@@ -1,6 +1,6 @@
 import { Body, Controller, Get, HttpException, HttpStatus, Param, Post } from "@nestjs/common";
 import { RoomsService } from "../service/rooms.service";
-import { CreateRoomDto } from "../dto/rooms.controller";
+import { CreateRoomDto, CreateUserDto } from "../dto/rooms.controller";
 import { RoomsRepository } from "../repository/rooms";
 import { UsersRepository } from "../repository/users";
 
@@ -16,6 +16,12 @@ export class RoomsController {
   createRoom(@Body() createRoomDto: CreateRoomDto) {
     const roomId = this.roomsService.createRoom(createRoomDto.category, createRoomDto.timeLimit);
     return roomId;
+  }
+
+  @Post(":roomId/user")
+  createUserInRoom(@Param("roomId") roomId: string, @Body() createUserDto: CreateUserDto) {
+    const userId = this.roomsService.createUserInRoom(createUserDto.userName, roomId)
+    return userId;
   }
 
   @Get(":roomId")

--- a/wordwolf-backend/src/rooms/controller/rooms.controller.ts
+++ b/wordwolf-backend/src/rooms/controller/rooms.controller.ts
@@ -1,14 +1,47 @@
-import { Controller, Post, Body } from "@nestjs/common";
+import { Body, Controller, Get, HttpException, HttpStatus, Param, Post } from "@nestjs/common";
 import { RoomsService } from "../service/rooms.service";
 import { CreateRoomDto } from "../dto/rooms.controller";
+import { RoomsRepository } from "../repository/rooms";
+import { UsersRepository } from "../repository/users";
 
 @Controller("room")
 export class RoomsController {
-  constructor(private readonly roomsService: RoomsService) {}
+  constructor(
+    private readonly roomsService: RoomsService,
+    private readonly roomsRepository: RoomsRepository,
+    private readonly usersRepository: UsersRepository,
+  ) {}
 
   @Post()
   createRoom(@Body() createRoomDto: CreateRoomDto) {
     const roomId = this.roomsService.createRoom(createRoomDto.category, createRoomDto.timeLimit);
     return roomId;
+  }
+
+  @Get(":roomId")
+  getRoomInfo(@Param("roomId") roomId: string) {
+    const room = this.roomsRepository.findBy(roomId);
+    if (room === undefined) {
+      throw new HttpException(
+        {
+          status: HttpStatus.NOT_FOUND,
+          error: `The room ${roomId} does not exist`,
+        },
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
+    const joinedUsers = this.usersRepository.joinedUsersOfRoom(roomId);
+
+    return {
+      roomId: room.roomId,
+      category: room.category,
+      timeLimit: room.timeLimit,
+      users: joinedUsers.map((u) => ({
+        userId: u.userId,
+        userName: u.userName,
+        isOwner: u.isOwner,
+      })),
+    };
   }
 }

--- a/wordwolf-backend/src/rooms/controller/rooms.controller.ts
+++ b/wordwolf-backend/src/rooms/controller/rooms.controller.ts
@@ -20,7 +20,7 @@ export class RoomsController {
 
   @Post(":roomId/user")
   createUserInRoom(@Param("roomId") roomId: string, @Body() createUserDto: CreateUserDto) {
-    const userId = this.roomsService.createUserInRoom(createUserDto.userName, roomId)
+    const userId = this.roomsService.createUserInRoom(createUserDto.userName, roomId);
     return userId;
   }
 

--- a/wordwolf-backend/src/rooms/controller/rooms.controller.ts
+++ b/wordwolf-backend/src/rooms/controller/rooms.controller.ts
@@ -44,7 +44,6 @@ export class RoomsController {
       category: room.category,
       timeLimit: room.timeLimit,
       users: joinedUsers.map((u) => ({
-        userId: u.userId,
         userName: u.userName,
         isOwner: u.isOwner,
       })),

--- a/wordwolf-backend/src/rooms/dto/rooms.controller.ts
+++ b/wordwolf-backend/src/rooms/dto/rooms.controller.ts
@@ -6,3 +6,8 @@ export class CreateRoomDto {
 
   timeLimit = "300";
 }
+
+export class CreateUserDto {
+  @IsNotEmpty()
+  userName!: string;
+}

--- a/wordwolf-backend/src/rooms/dto/rooms.gateway.ts
+++ b/wordwolf-backend/src/rooms/dto/rooms.gateway.ts
@@ -5,5 +5,5 @@ export class JoinRoomDto {
   roomId!: string;
 
   @IsNotEmpty()
-  userName!: string;
+  userId!: string;
 }

--- a/wordwolf-backend/src/rooms/entity/room.ts
+++ b/wordwolf-backend/src/rooms/entity/room.ts
@@ -1,14 +1,16 @@
 export class Room {
+  roomId: string;
+  category: string;
+  timeLimit: any;
+  createdAt: Date;
+
+  // TODO: 以下、要検討
+  state: "ready" | "playing" | "finish" = "ready";
+
   constructor(roomId: string, category: string, timeLimit: any, createdAt: Date) {
     this.roomId = roomId;
     this.category = category;
     this.timeLimit = timeLimit;
     this.createdAt = createdAt;
   }
-  roomId: string;
-  category: string;
-  // TODO: 以下、要検討
-  state: "ready" | "playing" | "finish" = "ready";
-  timeLimit: any;
-  createdAt: Date;
 }

--- a/wordwolf-backend/src/rooms/entity/user.ts
+++ b/wordwolf-backend/src/rooms/entity/user.ts
@@ -1,18 +1,38 @@
 export class User {
-  constructor(sessionId: string, connectionId: string, userName: string, isOwner: boolean, roomId: string) {
-    this.sessionId = sessionId;
-    this.connectionId = connectionId;
-    this.userName = userName;
-    this.isOwner = isOwner;
-    this.roomId = roomId;
-  }
-  // userのSessionのID
-  sessionId: string;
-  // Socket.IOのコネクションのID
-  connectionId: string;
+  // userのID
+  userId: string;
   userName: string;
-  isOwner: boolean;
+  // isOwnerは有効化するまではundefined
+  isOwner?: boolean;
   // TODO: roomIdからのUser参照が多すぎる場合、変更
   roomId: string;
   role?: string;
+
+  // 入室した状態かどうか
+  joined: boolean;
+
+  constructor(userId: string, userName: string, roomId: string) {
+    this.userId = userId;
+    this.userName = userName;
+    this.roomId = roomId;
+    this.joined = false;
+  }
+
+  get hasJoined(): boolean {
+    return this.joined;
+  }
+
+  /**
+   * 部屋に入室させる
+   */
+  joinRoom(): void {
+    this.joined = true;
+  }
+
+  /**
+   * 部屋のオーナーに設定する
+   */
+  setToBeOwner(): void {
+    this.isOwner = true;
+  }
 }

--- a/wordwolf-backend/src/rooms/gateway/rooms.gateway.ts
+++ b/wordwolf-backend/src/rooms/gateway/rooms.gateway.ts
@@ -20,6 +20,7 @@ export class RoomsGateway {
     const userId = body.userId;
     this.roomsService.joinRoom(userId, roomId);
     socket.join(roomId);
+    socket.to(roomId).emit("refresh");
     return userId;
   }
 }

--- a/wordwolf-backend/src/rooms/gateway/rooms.gateway.ts
+++ b/wordwolf-backend/src/rooms/gateway/rooms.gateway.ts
@@ -17,10 +17,9 @@ export class RoomsGateway {
   @SubscribeMessage("join-room")
   async joinRoom(@ConnectedSocket() socket: Socket, @MessageBody() body: JoinRoomDto): Promise<string> {
     const roomId = body.roomId;
-    const userName = body.userName;
-    const toBeOwner = (await this.io.in(roomId).fetchSockets()).length === 0;
-    const sessionId = this.roomsService.joinRoom(userName, socket.id, toBeOwner, roomId);
+    const userId = body.userId;
+    this.roomsService.joinRoom(userId, roomId);
     socket.join(roomId);
-    return sessionId;
+    return userId;
   }
 }

--- a/wordwolf-backend/src/rooms/repository/users.ts
+++ b/wordwolf-backend/src/rooms/repository/users.ts
@@ -4,7 +4,19 @@ import { User } from "../entity/user";
 @Injectable()
 export class UsersRepository {
   private users: User[] = [];
+
   store(user: User) {
     this.users.push(user);
+  }
+
+  findBy(userId: string): User | undefined {
+    return this.users.find((element) => element.userId === userId);
+  }
+
+  /**
+   * 部屋に入室済みのユーザ一覧を取得する
+   */
+  joinedUsersOfRoom(roomId: string): User[] {
+    return this.users.filter((u) => u.roomId === roomId && u.hasJoined);
   }
 }

--- a/wordwolf-backend/src/rooms/service/rooms.service.ts
+++ b/wordwolf-backend/src/rooms/service/rooms.service.ts
@@ -30,7 +30,7 @@ export class RoomsService {
    * @return ユーザID
    * @throws 部屋が存在しない場合はエラーとする
    */
-  makeUserInRoom(userName: string, roomId: string): string {
+  createUserInRoom(userName: string, roomId: string): string {
     const room = this.roomsRepository.findBy(roomId);
     if (room === undefined) {
       throw new Error(`room does not exist: ${roomId}`);

--- a/wordwolf-backend/src/rooms/service/rooms.service.ts
+++ b/wordwolf-backend/src/rooms/service/rooms.service.ts
@@ -8,6 +8,13 @@ import { UsersRepository } from "../repository/users";
 @Injectable()
 export class RoomsService {
   constructor(private readonly roomsRepository: RoomsRepository, private readonly usersRepository: UsersRepository) {}
+
+  /**
+   * 新しい部屋を作る
+   * @param category 部屋のデフォルトカテゴリー
+   * @param timeLimit 部屋のデフォルト議論時間
+   * @return 部屋ID
+   */
   createRoom(category: string, timeLimit: any): string {
     const roomId = randomUUID();
     const now = new Date();
@@ -16,14 +23,53 @@ export class RoomsService {
     return roomId;
   }
 
-  joinRoom(userName: string, connectionId: string, isOwner: boolean, roomId: string): string {
+  /**
+   * 部屋に新しくユーザを作る
+   * @param userName 新しいユーザのユーザ名
+   * @param roomId ユーザを作る部屋ID
+   * @return ユーザID
+   * @throws 部屋が存在しない場合はエラーとする
+   */
+  makeUserInRoom(userName: string, roomId: string): string {
     const room = this.roomsRepository.findBy(roomId);
     if (room === undefined) {
       throw new Error(`room does not exist: ${roomId}`);
     }
-    const sessionId = randomUUID();
-    const user = new User(sessionId, connectionId, userName, isOwner, roomId);
+
+    const userId = randomUUID();
+    const user = new User(userId, userName, roomId);
     this.usersRepository.store(user);
-    return sessionId;
+    return userId;
+  }
+
+  /**
+   * 作成済みのユーザを入室させる
+   * 最初に入室するユーザはオーナーとする
+   * @param userId ユーザID
+   * @param roomId 部屋ID
+   * @returns オーナーになったらtrue、そうでなければfalse
+   * @throws 部屋が存在しないかユーザが部屋に作成されていない場合はエラー
+   */
+  joinRoom(userId: string, roomId: string): boolean {
+    const room = this.roomsRepository.findBy(roomId);
+    if (room === undefined) {
+      throw new Error(`room does not exist: ${roomId}`);
+    }
+    const user = this.usersRepository.findBy(userId);
+    if (user === undefined) {
+      throw new Error(`user does not exist: ${userId}`);
+    }
+    if (user.roomId !== room.roomId) {
+      throw new Error(`user ${userId} does not exist in the room ${roomId}`);
+    }
+
+    user.joinRoom();
+
+    if (this.usersRepository.joinedUsersOfRoom(roomId).length === 0) {
+      user.setToBeOwner();
+      return true;
+    } else {
+      return false;
+    }
   }
 }

--- a/wordwolf-frontend/package.json
+++ b/wordwolf-frontend/package.json
@@ -21,7 +21,8 @@
     "modern-css-reset": "^1.4.0",
     "next": "13.3.3",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "socket.io-client": "^4.7.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",

--- a/wordwolf-frontend/src/pages/index.tsx
+++ b/wordwolf-frontend/src/pages/index.tsx
@@ -86,7 +86,7 @@ function MakingModal({ open, onClose, categories }: MakingModalProps) {
 
     localStorage.setItem(`adjwolves:${roomId}`, userId);
 
-    router.push({ pathname: "room", query: { roomId }});
+    router.push({ pathname: "room", query: { roomId } });
   };
 
   return (
@@ -132,25 +132,25 @@ function MakingModal({ open, onClose, categories }: MakingModalProps) {
  * @returns 部屋ID
  */
 async function createRoom(category: string, timeLimit: number): Promise<string> {
-    const postData = {
-      category,
-      timeLimit,
-    };
+  const postData = {
+    category,
+    timeLimit,
+  };
 
-    const endpoint = "http://localhost:3010/room";
-    const options = {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(postData),
-    };
+  const endpoint = "http://localhost:3010/room";
+  const options = {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(postData),
+  };
 
-    // TODO レスポンスが正しいかどうか検証する
-    const response = await fetch(endpoint, options);
-    const roomId = await response.text();
+  // TODO レスポンスが正しいかどうか検証する
+  const response = await fetch(endpoint, options);
+  const roomId = await response.text();
 
-    return roomId;
+  return roomId;
 }
 
 /**
@@ -158,21 +158,21 @@ async function createRoom(category: string, timeLimit: number): Promise<string> 
  * @returns ユーザID
  */
 async function createUserInRoom(userName: string, roomId: string): Promise<string> {
-    const postData = {
-      userName,
-    };
+  const postData = {
+    userName,
+  };
 
-    const endpoint = `http://localhost:3010/room/${roomId}/user`;
-    const options = {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(postData),
-    };
+  const endpoint = `http://localhost:3010/room/${roomId}/user`;
+  const options = {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(postData),
+  };
 
-    const response = await fetch(endpoint, options);
-    const userId = await response.text();
+  const response = await fetch(endpoint, options);
+  const userId = await response.text();
 
-    return userId;
+  return userId;
 }

--- a/wordwolf-frontend/src/pages/index.tsx
+++ b/wordwolf-frontend/src/pages/index.tsx
@@ -77,30 +77,16 @@ function MakingModal({ open, onClose, categories }: MakingModalProps) {
     };
 
     // TODO ちゃんと全体のバリデーションをする
-    if (dataRaw.timeLimit === undefined) {
+    if (dataRaw.timeLimit === undefined || dataRaw.category === undefined || dataRaw.userName === undefined) {
       return;
     }
 
-    const timeLimit = parseInt(dataRaw.timeLimit);
+    const roomId = await createRoom(dataRaw.category, parseInt(dataRaw.timeLimit));
+    const userId = await createUserInRoom(dataRaw.userName, roomId);
 
-    const postData = {
-      category: dataRaw.category,
-      timeLimit,
-    };
+    localStorage.setItem(`adjwolves:${roomId}`, userId);
 
-    const endpoint = "http://localhost:3010/room";
-    const options = {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(postData),
-    };
-
-    const response = await fetch(endpoint, options);
-    const roomId = await response.text();
-
-    router.push({ pathname: "room", query: { roomId, userName: dataRaw.userName } }, "room");
+    router.push({ pathname: "room", query: { roomId }});
   };
 
   return (
@@ -139,4 +125,54 @@ function MakingModal({ open, onClose, categories }: MakingModalProps) {
       </section>
     </Modal>
   );
+}
+
+/**
+ * バックエンドAPIを叩いて部屋を作る
+ * @returns 部屋ID
+ */
+async function createRoom(category: string, timeLimit: number): Promise<string> {
+    const postData = {
+      category,
+      timeLimit,
+    };
+
+    const endpoint = "http://localhost:3010/room";
+    const options = {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(postData),
+    };
+
+    // TODO レスポンスが正しいかどうか検証する
+    const response = await fetch(endpoint, options);
+    const roomId = await response.text();
+
+    return roomId;
+}
+
+/**
+ * バックエンドAPIを叩いてユーザを部屋内に作る
+ * @returns ユーザID
+ */
+async function createUserInRoom(userName: string, roomId: string): Promise<string> {
+    const postData = {
+      userName,
+    };
+
+    const endpoint = `http://localhost:3010/room/${roomId}/user`;
+    const options = {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(postData),
+    };
+
+    const response = await fetch(endpoint, options);
+    const userId = await response.text();
+
+    return userId;
 }

--- a/wordwolf-frontend/src/pages/room.tsx
+++ b/wordwolf-frontend/src/pages/room.tsx
@@ -30,9 +30,13 @@ export default function Room() {
   };
 
   useEffect(() => {
-    if (roomId === undefined) { return; }
+    if (roomId === undefined) {
+      return;
+    }
     const userId = localStorage.getItem(`adjwolves:${roomId}`);
-    if (userId === undefined) { return; }
+    if (userId === undefined) {
+      return;
+    }
 
     const socket = io("http://localhost:3010");
     socket.on("connect", () => {
@@ -52,7 +56,9 @@ export default function Room() {
       <p>部屋ID：{roomId}</p>
       <p>ユーザ</p>
       <ul>
-        {names.map((name) => <li key={name}>{name}</li>)}
+        {names.map((name) => (
+          <li key={name}>{name}</li>
+        ))}
       </ul>
       <Link href="/">トップに戻る</Link>
     </>

--- a/wordwolf-frontend/src/pages/room.tsx
+++ b/wordwolf-frontend/src/pages/room.tsx
@@ -1,14 +1,48 @@
 import Head from "next/head";
-import { ReactElement } from "react";
+import { ReactElement, useEffect, useState } from "react";
 import GameLayout from "@/components/GameLayout";
 import { useRouter } from "next/router";
 import Link from "next/link";
+import { io, Socket } from "socket.io-client";
 
 export default function Room() {
   const router = useRouter();
 
   const roomId = router.query.roomId;
-  const userName = router.query.userName;
+  const [socket, setSocket] = useState<Socket>();
+
+  const [names, setNames] = useState<string[]>([]);
+
+  const onRefresh = async () => {
+    const endpoint = `http://localhost:3010/room/${roomId}`;
+    const options = {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    };
+    const response = await fetch(endpoint, options);
+    const obj = await response.json();
+    console.log(obj);
+    setNames(obj.users.map((u) => u.userName));
+
+    console.log("refresh");
+  };
+
+  useEffect(() => {
+    if (roomId === undefined) { return; }
+    const userId = localStorage.getItem(`adjwolves:${roomId}`);
+    if (userId === undefined) { return; }
+
+    const socket = io("http://localhost:3010");
+    socket.on("connect", () => {
+      socket.emit("join-room", { roomId, userId });
+      console.log(`${userId} has joined to ${roomId}: ${socket.id}`);
+    });
+    socket.on("refresh", onRefresh);
+    onRefresh();
+    setSocket(socket);
+  }, [roomId]);
 
   return (
     <>
@@ -16,7 +50,10 @@ export default function Room() {
         <title>ワードウルフ {roomId}</title>
       </Head>
       <p>部屋ID：{roomId}</p>
-      <p>ユーザ名：{userName}</p>
+      <p>ユーザ</p>
+      <ul>
+        {names.map((name) => <li key={name}>{name}</li>)}
+      </ul>
       <Link href="/">トップに戻る</Link>
     </>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3296,10 +3296,26 @@ engine.io-client@~6.4.0:
     ws "~8.11.0"
     xmlhttprequest-ssl "~2.0.0"
 
+engine.io-client@~6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-6.5.1.tgz#1735fb8ae3bae5ae13115e18d2f484daf005dd9c"
+  integrity sha512-hE5wKXH8Ru4L19MbM1GgYV/2Qo54JSMh1rlJbfpa40bEWkCKNo3ol2eOtGmowcr+ysgbI7+SGL+by42Q3pt/Ng==
+  dependencies:
+    "@socket.io/component-emitter" "~3.1.0"
+    debug "~4.3.1"
+    engine.io-parser "~5.1.0"
+    ws "~8.11.0"
+    xmlhttprequest-ssl "~2.0.0"
+
 engine.io-parser@~5.0.3:
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-5.0.6.tgz#7811244af173e157295dec9b2718dfe42a64ef45"
   integrity sha512-tjuoZDMAdEhVnSFleYPCtdL2GXwVTGtNjoeJd9IhIG3C1xs9uwxqRNEu5WpnDZCaozwVlK/nuQhpodhXSIMaxw==
+
+engine.io-parser@~5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-5.1.0.tgz#d593d6372d7f79212df48f807b8cace1ea1cb1b8"
+  integrity sha512-enySgNiK5tyZFynt3z7iqBR+Bto9EVVVvDFuTT0ioHCGbzirZVGDGiQjZzEp8hWl6hd5FSVytJGuScX1C1C35w==
 
 engine.io@~6.4.1:
   version "6.4.2"
@@ -6431,10 +6447,28 @@ socket.io-client@^4.6.1:
     engine.io-client "~6.4.0"
     socket.io-parser "~4.2.1"
 
+socket.io-client@^4.7.1:
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-4.7.1.tgz#48e5f703abe4fb0402182bcf9c06b7820fb3453b"
+  integrity sha512-Qk3Xj8ekbnzKu3faejo4wk2MzXA029XppiXtTF/PkbTg+fcwaTw1PlDrTrrrU4mKoYC4dvlApOnSeyLCKwek2w==
+  dependencies:
+    "@socket.io/component-emitter" "~3.1.0"
+    debug "~4.3.2"
+    engine.io-client "~6.5.1"
+    socket.io-parser "~4.2.4"
+
 socket.io-parser@~4.2.1:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.2.2.tgz#1dd384019e25b7a3d374877f492ab34f2ad0d206"
   integrity sha512-DJtziuKypFkMMHCm2uIshOYC7QaylbtzQwiMYDuCKy3OPkjLzu4B2vAhTlqipRHHzrI0NJeBAizTK7X+6m1jVw==
+  dependencies:
+    "@socket.io/component-emitter" "~3.1.0"
+    debug "~4.3.1"
+
+socket.io-parser@~4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.2.4.tgz#c806966cf7270601e47469ddeec30fbdfda44c83"
+  integrity sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==
   dependencies:
     "@socket.io/component-emitter" "~3.1.0"
     debug "~4.3.1"


### PR DESCRIPTION
## やったこと

https://github.com/adjwolves/wordwolf/wiki/%E3%83%95%E3%83%AD%E3%83%B3%E3%83%88%E3%83%BB%E3%83%90%E3%83%83%E3%82%AF%E9%96%93%E9%80%9A%E4%BF%A1%E3%81%AE%E3%82%B7%E3%83%BC%E3%82%B1%E3%83%B3%E3%82%B9%E5%9B%B3

* ↑に沿って部屋が作れるようにバックエンドコードを変更
* フロントのAPI呼び出しも変更
* #16 と変わらず、フロントコードはバリデーションや型などは雑なまま
* ロビーページは動作確認ができる程度の完成度
  * socket.ioのrefreshが複数回呼ばれているなどまだ問題は多いが、いったんsocket.ioの動作確認はできるぐらい
* 追加したバックエンドのテストも全然やってない